### PR TITLE
fix: install litestream binary rather than attempt a dpkg install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .env.production
 *.db
 social-notifications
+bin/litestream

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: litestream replicate $DATABASE_FILE $LITESTREAM_REPLICA_URL
+web: bin/litestream replicate $DATABASE_FILE $LITESTREAM_REPLICA_URL

--- a/bin/install-litestream
+++ b/bin/install-litestream
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
+set -eo pipefail
 
-litestream_version="0.3.9"
-curl -sLo /tmp/litestream.deb "https://github.com/benbjohnson/litestream/releases/download/v${litestream_version}/litestream-v${litestream_version}-linux-amd64.deb"
-dpkg -i /tmp/litestream.deb
+litestream_version="0.3.13"
+curl -sLo /tmp/litestream.deb "https://github.com/benbjohnson/litestream/releases/download/v${litestream_version}/litestream-v${litestream_version}-linux-amd64.tar.gz"
+tar -xzf /tmp/litestream.deb -C bin
+test -x bin/litestream || exit 1


### PR DESCRIPTION
Scripts are now executed as the herokuishuser, and therefore don't have root access.